### PR TITLE
[19551] Bugfix

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1748,6 +1748,9 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
             will be converted back to CSC prior to being returned, hence the
             preference of CSR.
 
+            If the degree is 0 and include_bias is True, the function will
+            return a single column matrix of the bias.
+
         Returns
         -------
         XP : {ndarray, sparse matrix} of shape (n_samples, NP)
@@ -1765,6 +1768,11 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
 
         if n_features != self.n_input_features_:
             raise ValueError("X shape does not match training shape")
+
+        if self.degree < 1 and not self.include_bias:
+            raise ValueError("Found polynomial feature(s) with degree %d without"
+                            " including bias while a minimum of 1 is required."
+                            % (self.degree))
 
         if sparse.isspmatrix_csr(X):
             if self.degree > 3:
@@ -1822,6 +1830,9 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
                     current_col = 1
                 else:
                     current_col = 0
+
+                if self.degree == 0 and self.include_bias:
+                    return XP
 
                 # d = 0
                 XP[:, current_col:current_col + n_features] = X

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -290,6 +290,17 @@ def test_polynomial_features_csr_X_dim_edges(deg, dim, interaction_only):
     assert Xt_csr.dtype == Xt_dense.dtype
     assert_array_almost_equal(Xt_csr.A, Xt_dense)
 
+def test_polynomial_features_degree_zero():
+    # Degree 0 with include_bias = True should
+    # return a single column matrix of the bias
+    np.testing.assert_array_equal(PolynomialFeatures(degree=0,
+        include_bias=True).fit_transform(np.ones((10,1))),np.ones((10,1)))
+
+    # Degree 0 with include_bias = False should
+    # raise a ValueError instead of returning an empty matrix
+    with pytest.raises(ValueError):
+        PolynomialFeatures(degree=0,
+            include_bias=False).fit_transform(np.ones((10,1)))
 
 def test_raises_value_error_if_sample_weights_greater_than_1d():
     # Sample weights must be either scalar or 1D


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes issue 19551


#### What does this implement/fix? Explain your changes.
This fixes when PolynomialFeatures.transform fails when degree=0 and the input has more than one column.

#### Any other comments?
If the degree is 0 and include_bias is True, the function will return a single column matrix of the bias.
A ValueError is raised when fitting a PolynomialFeatures with degree=0 and include_bias=False.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
