### PR TITLE
Fixed Sequential Feature Selector - unsupervised fit issue with docs and test update

### DIFF
--- a/sklearn/feature_selection/_sequential.py
+++ b/sklearn/feature_selection/_sequential.py
@@ -115,7 +115,7 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin,
         self.cv = cv
         self.n_jobs = n_jobs
 
-    def fit(self, X, y):
+    def fit(self, X, y=None):
         """Learn the features to select.
 
         Parameters
@@ -123,18 +123,17 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin,
         X : array-like of shape (n_samples, n_features)
             Training vectors.
         y : array-like of shape (n_samples,)
-            Target values.
+            Target values. Defaults to None.
 
         Returns
         -------
         self : object
         """
         tags = self._get_tags()
-        X, y = self._validate_data(
-            X, y, accept_sparse="csc",
+        X = self._validate_data(
+            X, accept_sparse="csc",
             ensure_min_features=2,
-            force_all_finite=not tags.get("allow_nan", True),
-            multi_output=True
+            force_all_finite=not tags.get("allow_nan", True)
         )
         n_features = X.shape[1]
 

--- a/sklearn/feature_selection/tests/test_sequential.py
+++ b/sklearn/feature_selection/tests/test_sequential.py
@@ -10,6 +10,7 @@ from sklearn.datasets import make_regression
 from sklearn.linear_model import LinearRegression
 from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.cluster import KMeans
 
 
 @pytest.mark.parametrize('n_features_to_select', (0, 5, 0., -1, 1.1))
@@ -132,3 +133,9 @@ def test_pipeline_support():
     pipe = make_pipeline(StandardScaler(), sfs)
     pipe.fit(X, y)
     pipe.transform(X)
+
+def test_fit_without_labels():
+  data = np.array([[1,1,1,1,1], [2,2,2,2,2], [3,3,3,3,3], [4,4,4,4,4], [5,5,5,5,5], [6,6,6,6,6]])
+  model = KMeans(3)
+  sfs = SequentialFeatureSelector(model, n_features_to_select=3)
+  data = sfs.fit_transform(data)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes issue 19538


#### What does this implement/fix? Explain your changes.
This fixes the issue where the calling the SequentialFeatureSelector's fit/fit_transform method with a 'y' label as in unsupervised learning results in an error. 

#### Any other comments?
If the 'y' label is not given, it is defaulted to None. The docstrings are also updated to reflect the fix and an additional test case has been implemented. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
